### PR TITLE
Add support for multiple file extensions (e.g. "myfile.js.map")

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "node -r babel-register -r babel-polyfill src/index",
     "test": "NODE_ENV=test mocha --require babel-core/register",
     "test:watch": "npm t --  --watch",
-    "watch": "nodemon -r babel-register -r babel-polyfill src/index"
+    "watch": "nodemon -r babel-register -r babel-polyfill src/index",
+    "prepare": "npm run build"
   },
   "engines": {
     "node": ">=6.8.1"

--- a/src/traverser.js
+++ b/src/traverser.js
@@ -17,7 +17,7 @@ class Traverser {
     this.initialPath = initialPath
     this.excludes = excludes
     this.dest = dest
-    this.src = src
+    this.src = src.split('.')
   }
 
   async traverse (options = {}, rootPath = this.initialPath) {
@@ -43,10 +43,17 @@ class Traverser {
 
 const handleFile = async (file, filePath, src, dest, dry) => {
   const splitFilePath = filePath.split('.')
-  const filePathNoExt = splitFilePath[0]
-  const srcExt = splitFilePath[1]
 
-  if (srcExt === src) {
+  let match = true
+  for (let i = src.length - 1; i >= 0 && match; i--) {
+    if (src[i] !== splitFilePath.pop()) {
+      match = false
+    }
+  }
+
+  const filePathNoExt = splitFilePath.join('.')
+
+  if (match) {
     if (dry) {
       console.log('Will Rename: '.blue + `${filePath}`.red + ' --> '.yellow + `${filePathNoExt}.${dest}`.green)
     } else {

--- a/test/lib/fileSystemHelpers.js
+++ b/test/lib/fileSystemHelpers.js
@@ -21,8 +21,7 @@ function createTestDirectory (cb) {
         '&& mkdir -p test/mock/inner && touch test/mock/inner/file3.txt ' +
         '&& touch test/mock/inner/file4.jsx && ' +
         'touch test/mock/inner/file5.js && ' +
-        'touch test/mock/inner/file6.ext.map.js && ' +
-        'touch test/mock/inner/file7.map.js.dontrename && ' +
+        'touch test/mock/inner/file6.ext.js.map && ' +
         'mkdir test/mock/inner/deep && ' +
         'touch test/mock/inner/deep/file6.js && ' +
         'touch test/mock/inner/deep/file7.jsx && ' +

--- a/test/lib/fileSystemHelpers.js
+++ b/test/lib/fileSystemHelpers.js
@@ -21,11 +21,13 @@ function createTestDirectory (cb) {
         '&& mkdir -p test/mock/inner && touch test/mock/inner/file3.txt ' +
         '&& touch test/mock/inner/file4.jsx && ' +
         'touch test/mock/inner/file5.js && ' +
+        'touch test/mock/inner/file6.ext.map.js && ' +
+        'touch test/mock/inner/file7.map.js.dontrename && ' +
         'mkdir test/mock/inner/deep && ' +
-        'touch test/mock/inner/deep/file6.js &&' +
-        'touch test/mock/inner/deep/file7.jsx &&' +
+        'touch test/mock/inner/deep/file6.js && ' +
+        'touch test/mock/inner/deep/file7.jsx && ' +
         'mkdir -p test/mock/inner/deep/do-not-touch && ' +
-        'touch test/mock/inner/deep/do-not-touch/file8.jsx &&' +
+        'touch test/mock/inner/deep/do-not-touch/file8.jsx && ' +
         'touch test/mock/inner/deep/do-not-touch/file9.jsx ', (err, stdout, stderr) => {
     if (err) {
       console.log('Child process exited with error code', err)

--- a/test/traverser.test.js
+++ b/test/traverser.test.js
@@ -7,6 +7,10 @@ import {
 
 import Traverser from '../src/traverser'
 
+const generateExpectedOutput = (files, src, dest) => files.replace(
+  new RegExp(`^([a-zA-Z0-9.\\-\\/]*)\\.${src}$`, 'gm'),
+  `$1.${dest}`
+)
 
 describe('Traverser', () => {
   let traverseSpy
@@ -46,7 +50,7 @@ describe('Traverser', () => {
   it('renames source files to destination extension jsx -> js', async () => {
     return new Promise(resolve => {
       findTestDirectory(async filesBefore => {
-        const expectedOutput = filesBefore.replace(/\.jsx/g, '.js')
+        const expectedOutput = generateExpectedOutput(filesBefore, 'jsx', 'js')
 
         const traverser = new Traverser('test/mock', {
           src: 'jsx',
@@ -57,7 +61,7 @@ describe('Traverser', () => {
         await traverser.traverse()
 
         findTestDirectory(filesAfter => {
-          expect(expectedOutput).toBe(filesAfter)
+          expect(filesAfter).toBe(expectedOutput)
           expect(traverseSpy.calls.length).toBe(5)
 
           resolve()
@@ -69,7 +73,7 @@ describe('Traverser', () => {
   it('renames source files to destination extension txt -> doc', async () => {
     return new Promise(resolve => {
       findTestDirectory(async filesBefore => {
-        const expectedOutput = filesBefore.replace(/\.txt/g, '.doc')
+        const expectedOutput = generateExpectedOutput(filesBefore, 'txt', 'doc')
 
         const traverser = new Traverser('test/mock', {
           src: 'txt',
@@ -80,7 +84,7 @@ describe('Traverser', () => {
         await traverser.traverse()
 
         findTestDirectory(filesAfter => {
-          expect(expectedOutput).toBe(filesAfter)
+          expect(filesAfter).toBe(expectedOutput)
           expect(traverseSpy.calls.length).toBe(5)
 
           resolve()
@@ -96,8 +100,9 @@ describe('Traverser', () => {
 
         let expectedOutput = beforeArray.map(path => {
           if (!path.includes('do-not-touch')) {
-            if (path.includes('.jsx')) return path.replace(/\.jsx/g, '.js')
+            return generateExpectedOutput(path, 'jsx', 'js')
           }
+
           return path
         })
 
@@ -115,7 +120,7 @@ describe('Traverser', () => {
         await traverser.traverse()
 
         findTestDirectory(filesAfter => {
-          expect(expectedOutput).toBe(filesAfter)
+          expect(filesAfter).toBe(expectedOutput)
           expect(traverseSpy.calls.length).toBe(4)
 
           resolve()

--- a/test/traverser.test.js
+++ b/test/traverser.test.js
@@ -93,6 +93,29 @@ describe('Traverser', () => {
     })
   })
 
+  it('renames double extensions map.js -> map', async () => {
+    return new Promise(resolve => {
+      findTestDirectory(async filesBefore => {
+        const expectedOutput = generateExpectedOutput(filesBefore, 'map.js', 'map')
+
+        const traverser = new Traverser('test/mock', {
+          src: 'map.js',
+          dest: 'map',
+          excludes: new Set(),
+        })
+
+        await traverser.traverse()
+
+        findTestDirectory(filesAfter => {
+          expect(filesAfter).toBe(expectedOutput)
+          expect(traverseSpy.calls.length).toBe(5)
+
+          resolve()
+        })
+      })
+    })
+  })
+
   it('respects excludes flag when renaming', async () => {
     return new Promise(resolve => {
       findTestDirectory(async filesBefore => {

--- a/test/traverser.test.js
+++ b/test/traverser.test.js
@@ -93,14 +93,37 @@ describe('Traverser', () => {
     })
   })
 
-  it('renames double extensions map.js -> map', async () => {
+  it('renames double extensions js.map -> map and keeps preceeding extensions', async () => {
     return new Promise(resolve => {
       findTestDirectory(async filesBefore => {
-        const expectedOutput = generateExpectedOutput(filesBefore, 'map.js', 'map')
+        const expectedOutput = generateExpectedOutput(filesBefore, 'js.map', 'map')
 
         const traverser = new Traverser('test/mock', {
-          src: 'map.js',
+          src: 'js.map',
           dest: 'map',
+          excludes: new Set(),
+        })
+
+        await traverser.traverse()
+
+        findTestDirectory(filesAfter => {
+          expect(filesAfter).toBe(expectedOutput)
+          expect(traverseSpy.calls.length).toBe(5)
+
+          resolve()
+        })
+      })
+    })
+  })
+
+  it('deos not rename files where the src extension is not the last extension', async () => {
+    return new Promise(resolve => {
+      findTestDirectory(async filesBefore => {
+        const expectedOutput = generateExpectedOutput(filesBefore, 'js', 'mjs')
+
+        const traverser = new Traverser('test/mock', {
+          src: 'js',
+          dest: 'mjs',
           excludes: new Set(),
         })
 


### PR DESCRIPTION
Currently files with multiple extensions are not supported (`js.map` won't match at all). In addition only the sequence behind the first dot is checked, which results in `js` matching `myfile.js.map` - this is not desirable most of the time.

This PR aims at fixing this. However the changed behavior will most likely require a major version bump (although it can be considered a fix as well).

In addition I added a `prepare` script to the `package.json` which allows for direct installs from Git and ensurers that on `npm publish` it's always the latest build which get published.

See #7